### PR TITLE
Add privacy policy and terms of service documents

### DIFF
--- a/SmokeBot/PRIVACY_POLICY.md
+++ b/SmokeBot/PRIVACY_POLICY.md
@@ -1,0 +1,69 @@
+# SmokeBot Privacy Policy
+
+_Last updated: 2024-05-06_
+
+SmokeBot is a Discord moderation and support assistant developed for deployment by individual server owners. This Privacy Policy explains what limited information the bot processes when it operates in a Discord server, how that information is used, and the choices available to server administrators and members.
+
+## 1. Information We Process
+SmokeBot only accesses data that Discord makes available to bots in servers where it has been invited. The bot does not collect information outside of Discord. Depending on the features that have been enabled by server administrators, SmokeBot may process:
+
+### 1.1 Ticketing system
+* Discord user IDs for the member who created the ticket and staff who interact with it
+* Category selection, ticket status, creation and closure timestamps
+* The channel or thread ID that hosts the ticket conversation
+* Any messages voluntarily posted in the ticket thread (handled directly on Discord – not stored by the bot)
+
+### 1.2 Reaction roles
+* Message IDs, emoji identifiers, and the role ID that should be granted or removed
+* Guild (server) IDs necessary to apply the role
+
+### 1.3 Snippets
+* Per‑guild snippet triggers and the text that should be posted when a trigger is used
+* Whether a snippet is dynamic and any placeholder structure configured by server staff
+
+### 1.4 Persistent pins
+* The text content configured for the persistent pin
+* The IDs for the message, channel, guild, and the administrator who set the pin
+
+### 1.5 Moderation utilities
+* When moderation commands such as timeout, kick, ban, or message purge are run, SmokeBot processes the relevant Discord IDs and command parameters in memory to complete the request. These actions are executed against Discord’s APIs and are not stored by the bot after completion.
+
+SmokeBot requires access to message content in servers where administrators enable snippet functionality or pin reposting. This access is limited to reading messages in channels where the bot has permission so that it can detect snippet triggers and keep tracked pins up to date.
+
+## 2. How We Use Information
+The information described above is used solely to:
+
+* Provide and manage the ticketing, snippet, pin, reaction role, and moderation features requested by server administrators
+* Maintain command configuration across restarts by storing the minimum required settings in local JSON files on the host machine (`ticket_data.json`, `reaction_roles.json`, `snippets.json`, `pinned_messages.json`, `ticket_categories.json`)
+* Respond to slash commands and interaction events routed through Discord
+
+SmokeBot does not use the data for analytics, advertising, or any secondary purposes.
+
+## 3. Where Information Is Stored
+All configuration data is stored locally on the machine that hosts SmokeBot. No data is transmitted to external third parties other than Discord’s platform APIs. Server owners are responsible for securing the machine where the bot runs, including restricting access to the JSON configuration files mentioned above.
+
+## 4. Data Retention and Deletion
+Stored configuration data remains in place until a server administrator edits or removes it (for example, by deleting a snippet or clearing ticket history) or until the underlying JSON files are deleted from the host machine. Ticket threads themselves remain on Discord until archived or deleted by server staff.
+
+Server administrators may request removal of stored configuration data at any time by deleting the corresponding JSON files or by contacting the bot operator. Because SmokeBot is self‑hosted, the operator is typically the server owner or maintainer who deployed the bot.
+
+## 5. Legal Basis
+For servers operating under the EU/EEA, SmokeBot processes the limited personal data described above under the legitimate interest of the server administrators who deploy the bot to moderate and support their community.
+
+## 6. Security
+The bot relies on the hosting operator to provide physical and network security. SmokeBot itself restricts access to stored data by only reading and writing to the local file system. Administrators should keep the hosting environment up to date, safeguard the Discord bot token, and limit operating system access to trusted individuals.
+
+## 7. Children’s Privacy
+SmokeBot does not knowingly collect personal information from children. Discord requires users to be at least 13 years old (or the minimum age in their jurisdiction) to use the platform. Server owners should ensure their communities comply with Discord’s Terms of Service.
+
+## 8. Third‑Party Services
+SmokeBot interacts exclusively with Discord’s APIs. Use of the bot is also subject to Discord’s own policies, including the [Discord Terms of Service](https://discord.com/terms) and [Privacy Policy](https://discord.com/privacy).
+
+## 9. Changes to This Policy
+We may update this Privacy Policy to reflect improvements or legal requirements. When changes are made, the “Last updated” date at the top of this page will be revised. Material changes will be communicated to server administrators through the project repository or release notes.
+
+## 10. Contact
+Because SmokeBot is typically self‑hosted, the primary contact for privacy requests is the individual or team that operates the bot in your server. If you obtained SmokeBot from a public repository, please use the contact information provided there to reach the maintainer.
+
+---
+By continuing to use SmokeBot in your server, you acknowledge that you have read and understood this Privacy Policy.

--- a/SmokeBot/TERMS_OF_SERVICE.md
+++ b/SmokeBot/TERMS_OF_SERVICE.md
@@ -1,0 +1,57 @@
+# SmokeBot Terms of Service
+
+_Last updated: 2024-05-06_
+
+These Terms of Service ("Terms") govern the use of SmokeBot, a Discord moderation and support bot. By inviting or using SmokeBot in your Discord server, you agree to be bound by these Terms. If you do not agree, do not deploy or interact with the bot.
+
+## 1. Eligibility and Account Responsibility
+* SmokeBot may only be installed by individuals who have the authority to manage the Discord server where it will operate.
+* You must comply with Discord’s Terms of Service, Community Guidelines, and any applicable local laws.
+* Server administrators are responsible for managing access to the bot token and the environment where SmokeBot is hosted.
+
+## 2. Bot Functionality
+SmokeBot offers ticketing, snippet automation, persistent pins, reaction roles, and moderation utilities. The bot processes Discord data only as necessary to provide these features. Configuration data is stored locally on the host machine as JSON files (`ticket_data.json`, `reaction_roles.json`, `snippets.json`, `pinned_messages.json`, `ticket_categories.json`).
+
+## 3. Acceptable Use
+When using SmokeBot, you agree not to:
+* Violate Discord’s policies or any applicable law.
+* Use the bot to harass, discriminate against, or exploit other users.
+* Attempt to access or modify the bot’s source code or data files without authorization from the operator.
+* Interfere with the bot’s operation, including attempting to overload, reverse engineer, or disrupt the service.
+
+Server administrators should configure permissions so that only trusted staff can run moderation or configuration commands.
+
+## 4. Data Practices
+Details about the data SmokeBot processes are described in the [Privacy Policy](./PRIVACY_POLICY.md). By operating or using the bot, you acknowledge that the limited information outlined there may be processed to deliver the requested features.
+
+## 5. Self‑Hosting and Availability
+SmokeBot is typically self‑hosted. You are solely responsible for:
+* Deploying and maintaining the hosting environment
+* Installing updates and security patches
+* Backing up or deleting configuration data as needed
+
+Because operation depends on your hosting environment and Discord’s platform availability, we do not guarantee uptime, response time, or error-free performance. Features may change or be discontinued without notice.
+
+## 6. Support
+Support is provided on a best-effort basis by the maintainer(s). There is no obligation to provide assistance, bug fixes, or feature updates. Community contributions may be accepted at the maintainer’s discretion.
+
+## 7. Termination
+Server administrators may remove SmokeBot at any time by revoking its invite, deleting the bot token, and/or stopping the hosting process. We may suspend or terminate access to the bot (including blocking abusive instances) if these Terms or Discord’s policies are violated.
+
+## 8. Disclaimer of Warranties
+SMOKEBOT IS PROVIDED "AS IS" AND "AS AVAILABLE" WITHOUT WARRANTIES OF ANY KIND, WHETHER EXPRESS OR IMPLIED, INCLUDING WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE, AND NON‑INFRINGEMENT. YOUR USE OF THE BOT IS AT YOUR OWN RISK.
+
+## 9. Limitation of Liability
+To the maximum extent permitted by law, the maintainer(s) of SmokeBot will not be liable for any indirect, incidental, special, consequential, or punitive damages, or any loss of profits or revenues, whether incurred directly or indirectly, or any loss of data, use, goodwill, or other intangible losses, resulting from (a) your access to or use of the bot; (b) any conduct or content of any third party; or (c) unauthorized access, use, or alteration of your transmissions or data.
+
+## 10. Indemnification
+You agree to indemnify and hold harmless the maintainer(s) of SmokeBot from any claim, demand, loss, or damage, including reasonable attorneys’ fees, arising out of or related to your use or misuse of the bot, violation of these Terms, or breach of any representation or warranty herein.
+
+## 11. Changes to These Terms
+We may update these Terms from time to time. When changes are made, the “Last updated” date will be revised. Material changes will be announced through the project repository or release notes. Continued use of SmokeBot after changes become effective constitutes acceptance of the updated Terms.
+
+## 12. Contact
+Because SmokeBot is typically self‑hosted, contact the individual or team operating the bot in your server for any questions regarding these Terms. If you obtained the bot from a public repository, use the communication channels provided there.
+
+---
+By inviting or using SmokeBot, you acknowledge that you have read, understood, and agree to these Terms of Service.


### PR DESCRIPTION
## Summary
- add a SmokeBot-specific privacy policy describing stored configuration data and usage of Discord information
- define terms of service covering acceptable use, responsibilities, and legal disclaimers for hosting the bot

## Testing
- not run (documentation-only changes)

------
https://chatgpt.com/codex/tasks/task_e_68cf2740dc408330ad089954e4b43353