### PR TITLE
Handle commands without mention in help

### DIFF
--- a/SmokeBot/main.py
+++ b/SmokeBot/main.py
@@ -1488,7 +1488,14 @@ async def clear_messages(
 async def help_mod(interaction: discord.Interaction):
     def cmd(name: str) -> str:
         command = bot.tree.get_command(name)
-        return command.mention if command else f"/{name}"
+        if not command:
+            return f"/{name}"
+
+        mention = getattr(command, "mention", None)
+        if mention:
+            return mention
+
+        return f"/{command.qualified_name}"
 
     embed = discord.Embed(
         title="🛡️ Bot Commands",


### PR DESCRIPTION
## Summary
- ensure the /help command gracefully falls back to command names when a slash command does not expose a mention attribute
- keep the existing mention formatting when available so linked commands still work

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_690170c957e88330b21b741688d36893