### PR TITLE
Stop processing prefixed commands after snippet replies

### DIFF
--- a/SmokeBot/main.py
+++ b/SmokeBot/main.py
@@ -826,6 +826,62 @@ async def start_giveaway(
 # Snippet Commands (with migration + dynamic placeholders)
 # =====================================================
 
+class SnippetEditModal(discord.ui.Modal):
+    """Modal that allows editing snippet content with multiline support."""
+
+    def __init__(
+        self,
+        *,
+        guild_id: str,
+        trigger: str,
+        initial_content: str = "",
+        dynamic: Optional[bool] = None,
+        existed: bool = True,
+    ) -> None:
+        title = f"Snippet: !{trigger}" if trigger else "Snippet Editor"
+        super().__init__(title=title[:45])  # Discord limits modal titles to 45 chars
+
+        self.guild_id = guild_id
+        self.trigger = trigger
+        self.dynamic = dynamic
+        self.existed = existed
+
+        self.content_input = discord.ui.TextInput(
+            label="Snippet Content",
+            style=discord.TextStyle.paragraph,
+            default=initial_content[:1900],  # stay well under 2000 char limit
+            max_length=1900,
+            placeholder="Enter the snippet text. Supports new lines.",
+            required=True,
+        )
+
+        self.add_item(self.content_input)
+
+    async def on_submit(self, interaction: discord.Interaction) -> None:
+        content = str(self.content_input.value).strip()
+
+        if not content:
+            return await interaction.response.send_message(
+                "❌ Snippet content cannot be empty.", ephemeral=True
+            )
+
+        guild_snippets = snippets.setdefault(self.guild_id, {})
+        existing_entry = guild_snippets.get(self.trigger, {})
+        dynamic_flag = (
+            existing_entry.get("dynamic", False)
+            if self.dynamic is None
+            else bool(self.dynamic)
+        )
+
+        guild_snippets[self.trigger] = {"content": content, "dynamic": dynamic_flag}
+        save_snippets()
+
+        action = "updated" if self.existed else "created"
+        await interaction.response.send_message(
+            f"✅ Snippet `!{self.trigger}` {action}.", ephemeral=True
+        )
+
+
 @bot.tree.command(name="addsnippet", description="Add a static snippet")
 @app_commands.describe(trigger="Trigger word (no !)", content="Content to send")
 async def add_snippet(interaction: discord.Interaction, trigger: str, content: str):
@@ -875,6 +931,45 @@ async def edit_dynamic_snippet(interaction: discord.Interaction, trigger: str, c
         save_snippets()
         return await interaction.response.send_message(f"✅ Dynamic snippet `!{trigger}` updated.", ephemeral=True)
     await interaction.response.send_message("❌ Snippet not found.", ephemeral=True)
+
+
+@bot.tree.command(
+    name="advancededitsnippet",
+    description="Open a modal to edit snippet content with multiline support",
+)
+@app_commands.describe(
+    trigger="Trigger word (no !)",
+    dynamic="Optional override for dynamic mode (leave blank to keep current)",
+)
+async def advanced_edit_snippet(
+    interaction: discord.Interaction, trigger: str, dynamic: Optional[bool] = None
+):
+    if not has_permissions_or_override(interaction):
+        return await interaction.response.send_message("❌ No permission.", ephemeral=True)
+
+    trigger = trigger.lstrip("!")
+    gid = str(interaction.guild.id)
+    existing = snippets.get(gid, {}).get(trigger)
+
+    if existing:
+        initial_content = existing.get("content", "")
+        default_dynamic = existing.get("dynamic", False)
+        existed = True
+    else:
+        initial_content = ""
+        default_dynamic = False
+        existed = False
+
+    modal = SnippetEditModal(
+        guild_id=gid,
+        trigger=trigger,
+        initial_content=initial_content,
+        dynamic=dynamic if dynamic is not None else default_dynamic,
+        existed=existed,
+    )
+
+    await interaction.response.send_modal(modal)
+
 
 @bot.tree.command(name="removesnippet", description="Remove a static snippet")
 @app_commands.describe(trigger="Trigger word (no !)")
@@ -927,49 +1022,52 @@ async def on_message(message):
     await handle_pin_repost(message)
 
     # Snippet handling (messages starting with "!")
-    if not message.content.startswith("!"):
-        return
+    if message.content.startswith("!"):
+        if not message.guild:
+            return
 
-    gid = str(message.guild.id)
-    parts = message.content.split()
-    if not parts:
-        return
+        gid = str(message.guild.id)
+        parts = message.content.split()
+        if parts:
+            trigger = parts[0][1:]
 
-    trigger = parts[0][1:]
+            if gid in snippets and trigger in snippets[gid]:
+                entry = snippets[gid][trigger]
+                content = entry["content"]
+                is_dynamic = entry.get("dynamic", False)
 
-    if gid in snippets and trigger in snippets[gid]:
-        entry = snippets[gid][trigger]
-        content = entry["content"]
-        is_dynamic = entry.get("dynamic", False)
+                # Delete the original trigger message to keep channels clean
+                try:
+                    await message.delete()
+                except discord.Forbidden:
+                    pass
 
-        # Delete the original trigger message to keep channels clean
-        try:
-            await message.delete()
-        except discord.Forbidden:
-            pass
+                if is_dynamic:
+                    # Replace placeholders {1}, {2}, ... globally.
+                    args = parts[1:]
+                    for i, arg in enumerate(args, start=1):
+                        content = content.replace(f"{{{i}}}", arg)
+                    # Remove any unused {n} placeholders
+                    content = re.sub(r"\{\d+\}", "", content)
 
-        if is_dynamic:
-            # Replace placeholders {1}, {2}, ... globally.
-            args = parts[1:]
-            for i, arg in enumerate(args, start=1):
-                content = content.replace(f"{{{i}}}", arg)
-            # Remove any unused {n} placeholders
-            content = re.sub(r"\{\d+\}", "", content)
+                # If the snippet was used as a reply, mention the original author first.
+                if message.reference and message.reference.message_id:
+                    try:
+                        replied = await message.channel.fetch_message(message.reference.message_id)
+                        content = f"{replied.author.mention} {content}"
+                    except discord.NotFound:
+                        pass
 
-        # If the snippet was used as a reply, mention the original author first.
-        if message.reference and message.reference.message_id:
-            try:
-                replied = await message.channel.fetch_message(message.reference.message_id)
-                content = f"{replied.author.mention} {content}"
-            except discord.NotFound:
-                pass
+                try:
+                    await message.channel.send(content)
+                except discord.Forbidden:
+                    await message.channel.send(
+                        f"⚠️ I don't have permission to send messages! Snippet would be: {content}"
+                    )
 
-        try:
-            await message.channel.send(content)
-        except discord.Forbidden:
-            await message.channel.send(f"⚠️ I don't have permission to send messages! Snippet would be: {content}")
+                return
 
-    # Keep slash commands working
+    # Keep slash commands and prefixed commands working
     await bot.process_commands(message)
 
 # =====================================================


### PR DESCRIPTION
## Summary
- short-circuit snippet handling once a matching trigger is processed so deleted messages don't fall through to prefix parsing
- guard against DM usage while still allowing other prefixed commands to run when no snippet is found

## Testing
- python -m compileall SmokeBot/main.py

------
https://chatgpt.com/codex/tasks/task_e_690408d2c54c8330bb7aa4c2a0889061