### PR TITLE
Fix auto reply migration defaults

### DIFF
--- a/SmokeBot/main.py
+++ b/SmokeBot/main.py
@@ -559,14 +559,16 @@ def load_auto_replies():
         for name, data in list(replies.items()):
             if not isinstance(data, dict):
                 raw[guild_id][name] = ensure_autoreply_defaults({
-                    "pattern": str(data),
-                    "response": "",
+                    "pattern": name,
+                    "response": str(data),
                     "dynamic": False,
                 })
                 migrated = True
             else:
                 before = dict(data)
                 raw[guild_id][name] = ensure_autoreply_defaults(data)
+                if not raw[guild_id][name].get("pattern"):
+                    raw[guild_id][name]["pattern"] = name
                 if raw[guild_id][name] != before:
                     migrated = True
 


### PR DESCRIPTION
## Summary
- ensure legacy auto-reply entries migrate the old response text instead of leaving it empty
- fall back to the auto-reply name as the pattern when legacy data does not include one

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_690d1d50a1588330bcf65f237e18a59f