### PR TITLE
Add guild-limited script triggers

### DIFF
--- a/SmokeBot/main.py
+++ b/SmokeBot/main.py
@@ -1954,10 +1954,19 @@ script_group = app_commands.Group(
 
 async def reject_script_guild(interaction: discord.Interaction) -> bool:
     if not script_guild_allowed(interaction.guild):
-        await interaction.response.send_message(
-            "❌ Script triggers are not enabled for this server.",
-            ephemeral=True,
-        )
+        try:
+            if interaction.response.is_done():
+                await interaction.followup.send(
+                    "❌ Script triggers are not enabled for this server.",
+                    ephemeral=True,
+                )
+            else:
+                await interaction.response.send_message(
+                    "❌ Script triggers are not enabled for this server.",
+                    ephemeral=True,
+                )
+        except discord.HTTPException:
+            pass
         return True
     return False
 


### PR DESCRIPTION
### Motivation

- Provide a way to run small Python scripts on message triggers (send/reply/react helpers) for automation and custom behavior.
- Restrict script execution to a controlled set of guilds to limit risk and scope.
- Expose management UI via slash commands so admins can add/remove/list scripts per server.

### Description

- Added a new script trigger system backed by `script_triggers.json` with `load_/save_script_triggers` and default normalization via `ensure_script_trigger_defaults`.
- Introduced `ALLOWED_SCRIPT_GUILDS` (currently containing `1385295315245989999`) and `script_guild_allowed` gating so triggers only run in allowlisted guilds.
- Implemented safe execution helpers (`send`, `reply`, `react`, async scheduling) and a restricted `__builtins__` environment used by `run_script_trigger` to `exec` user-provided code, and wired message matching via `message_trigger_match` inside `on_message`.
- Added slash commands group `/script` with `set`, `remove`, and `list` to manage script triggers and updated the help embed to include script commands; also added `traceback` import for error logging.

### Testing

- No automated tests were executed for this change.
- Basic static checks: file saved and added to repository (no runtime tests performed).
- Manual runtime verification is recommended in a controlled environment before enabling additional guilds.
- Review and audit of script code and allowed helpers is recommended due to `exec` usage.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69630cb5d8708330acec939dc7366e79)